### PR TITLE
Fix composeEnhancers function declaration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ import loadingReducer from './store/reducers/loading';
 import sendSignEnvReducer from './store/reducers/sendSignEnv';
 
 const composeEnhancers = (process.env.NODE_ENV === 'development' ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ : null) || compose;
-console.log(window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__);
 const rootReducer = combineReducers({
     dsAuth: dsAuthReducer,
     listEnv: listEnvReducer,

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ import listEnvReducer from './store/reducers/listEnv';
 import loadingReducer from './store/reducers/loading';
 import sendSignEnvReducer from './store/reducers/sendSignEnv';
 
-const composeEnhancers = process.env.NODE_ENV === 'development' ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ : null || compose;
-
+const composeEnhancers = (process.env.NODE_ENV === 'development' ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ : null) || compose;
+console.log(window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__);
 const rootReducer = combineReducers({
     dsAuth: dsAuthReducer,
     listEnv: listEnvReducer,


### PR DESCRIPTION
App does not start if user does not have Redux devtools extension installed.
Get error:
<img width="1062" alt="Screen Shot 2019-05-28 at 4 26 45 PM" src="https://user-images.githubusercontent.com/6571449/58509821-74a28a00-8165-11e9-860e-89baa8ee87a8.png">

PR wraps ternary evaluation in parentheses so `compose` fn of redux package becomes default value